### PR TITLE
Missing text restored

### DIFF
--- a/5233-h/5233-h.htm
+++ b/5233-h/5233-h.htm
@@ -13247,7 +13247,42 @@ shocked and hurt her.
 </P>
 
 <P>
-"We can't build the S. R.
+"We can't build the S. R. & N. on four thousand dollars," he 
+protested, bitterly. "I need my half."
+</P>
+
+<P>
+"You'll get it back sometime."
+</P>
+
+<P>
+"Oh! Will I? Well, I don't want it 'sometime'; I want it now. Why, 
+the idea is ridiculous &mdash; just like a woman!"
+</P>
+
+<P>
+"When was I ever 'just like a woman'?" cried Eliza. "Don't be ironic 
+&mdash; it hurts. Never mind," she said, in answer to his look of 
+bewilderment; "just listen. Mr. O'Neil will succeed. I'm sure he 
+will. But he needs time &mdash; even a week may save him. You've 
+risked your life for the road; you've suffered&mdash;"
+</P>
+
+<P>
+"That's different!" said Dan, irritably. "That was part of my work. I 
+earned my money, and I saved it. I need it now, for &mdash; you know 
+&mdash; for Natalie. I can't afford to be penniless &mdash; I can't 
+get along without her. If Murray goes bust, where will I land? Out in 
+the street! I've been so lonesome since she left that I can't work 
+&mdash; I thought you understood &mdash; I can't think; I can't 
+sleep, nor eat!&mdash;"
+</P>
+
+<P>
+"And what about him?" demanded the girl, with heat. "Do you think 
+he's eating and sleeping any better than you? He made you, Dan! He 
+took me in and treated me as a valued friend when he knew I was his 
+enemy. He&mdash;"
 </P>
 
 <P>

--- a/5233-h/5233-h.htm
+++ b/5233-h/5233-h.htm
@@ -13247,7 +13247,7 @@ shocked and hurt her.
 </P>
 
 <P>
-"We can't build the S. R. & N. on four thousand dollars," he 
+"We can't build the S. R. &amp; N. on four thousand dollars," he 
 protested, bitterly. "I need my half."
 </P>
 

--- a/5233.txt
+++ b/5233.txt
@@ -8962,7 +8962,31 @@ shocked and hurt her.
 
 "You--WHAT?"
 
-"We can't build the S. R.
+"We can't build the S. R. & N. on four thousand dollars," he protested, 
+bitterly. "I need my half."
+
+"You'll get it back sometime."
+
+"Oh! Will I? Well, I don't want it 'sometime'; I want it now. Why, the 
+idea is ridiculous -- just like a woman!"
+
+"When was I ever 'just like a woman'?" cried Eliza. "Don't be ironic 
+-- it hurts. Never mind," she said, in answer to his look of 
+bewilderment; "just listen. Mr. O'Neil will succeed. I'm sure he will. 
+But he needs time -- even a week may save him. You've risked your life 
+for the road; you've suffered--"
+
+"That's different!" said Dan, irritably. "That was part of my work. I 
+earned my money, and I saved it. I need it now, for -- you know -- for 
+Natalie. I can't afford to be penniless -- I can't get along without 
+her. If Murray goes bust, where will I land? Out in the street! I've 
+been so lonesome since she left that I can't work -- I thought you 
+understood -- I can't think; I can't sleep, nor eat!--"
+
+"And what about him?" demanded the girl, with heat. "Do you think 
+he's eating and sleeping any better than you? He made you, Dan! He 
+took me in and treated me as a valued friend when he knew I was his 
+enemy. He--"
 
 "Yes, and made you love him, too," said Dan, roughly. "I can see that."
 


### PR DESCRIPTION
Restored five and a half paragraphs that were left out of the Gutenberg file, transcribed from page images of the first edition [found on Google Books](https://books.google.com/books/about/The_iron_trail.html?id=7YchAAAAMAAJ&hl=en). 

The missing text was found on page 273 of the 1913 first edition, page 296 of the PDF file, and transcribed by hand.
